### PR TITLE
旧リポジトリで翻訳済のページを反映

### DIFF
--- a/administration-menus/index.md
+++ b/administration-menus/index.md
@@ -1,13 +1,41 @@
+<!--
 # Administration Menus
+-->
 
+# 管理メニュー
+
+<!--
 Administration Menus are the interfaces displayed in WordPress Administration. They allow you to add option pages for your plugin.
+-->
 
+管理メニューは WordPress の管理画面に表示されるインターフェイスです。プラグインのオプションページを追加できます。
+
+<!--
 [info]For information on managing Navigation Menus, see the Navigation Menus chapter of the Theme Developer Handbook.[/info]
+-->
 
+[info]ナビゲーションメニューの管理については、テーマ開発ハンドブックのナビゲーションメニューの章を参照してください。[/info]
+
+<!--
 ## Top-Level Menus and Sub-Menus
+-->
 
+## トップレベルメニューとサブメニュー
+
+<!--
 The Top-level menus are rendered along the left side of the WordPress Administration. Each menu may contain a set of Sub-menus.
+-->
 
+トップレベルメニューは WordPress 管理画面の左側に表示されます。各メニューはサブメニューのセットを含むことができます。
+
+<!--
 When deciding between [Top-level menus](https://developer.wordpress.org/plugins/administration-menus/top-level-menus/) and [Sub-menus](https://developer.wordpress.org/plugins/administration-menus/sub-menus/) think carefully about the needs of your plugin as well as the needs of your end users.
+-->
 
+[トップレベルメニュー](https://developer.wordpress.org/plugins/administration-menus/top-level-menus/)と[サブメニュー](https://developer.wordpress.org/plugins/administration-menus/sub-menus/)のどちらを使うかを決めるときは、プラグインのニーズとエンドユーザーのニーズをよく考えてください。
+
+<!--
 [alert]We recommend developers with a single option page to add it as Sub-menu to one of the existing Top-level menus; such as Settings or Tools.[/alert]
+-->
+
+[alert]単一のオプションページの場合は、設定やツールなどの既存のトップレベルメニューのサブメニューとして追加することをおすすめします。[/alert]

--- a/credits/index.md
+++ b/credits/index.md
@@ -1,6 +1,14 @@
+<!--
 # Credits
+-->
 
+# クレジット
+
+<!--
 List of credits brought over manually.
+-->
+
+以下のクレジットは手動で追加されています。
 
 - @2Neil
 - @aternus

--- a/developer-tools/index.md
+++ b/developer-tools/index.md
@@ -1,3 +1,11 @@
+<!--
 # Developer Tools
+-->
 
+# 開発者ツール
+
+<!--
 There are a wide variety of tools available to help with plugin development. Some of them are run in your development environment ([xdebug](https://xdebug.org/), [PHPCS](https://github.com/WordPress/WordPress-Coding-Standards), etc), but there are also some excellent tools that can run right inside WordPress to help you build things properly and diagnose problems. This chapter deals with the in-browser tools.
+-->
+
+プラグイン開発に役立つさまざまなツールが用意されています。それらの一部は開発環境 ([xdebug](http://xdebug.org/)、[PHPCS](https://github.com/WordPress/WordPress-Coding-Standards) など) で実行されますが、WordPress 内で直接実行され、開発や問題の診断に役立つ優れたツールもいくつかあります。この章ではブラウザ内ツールについて説明します。

--- a/index.md
+++ b/index.md
@@ -1,9 +1,22 @@
+<!--
 # Plugin Handbook
+-->
 
+# プラグインハンドブック
+
+<!--
 _Welcome to the WordPress Plugin Developer Handbook; are you ready to jump right in to the world of WordPress plugins?_
+-->
 
+WordPress プラグイン開発者ハンドブックへようこそ。WordPress プラグインの世界にすぐに飛び込む準備はできていますか ?
+
+<!--
 The Plugin Developer Handbook is a resource for all things WordPress plugins. Whether you're new to WordPress plugin development, or you're an experienced plugin developer, you should be able to find the answer to many of your plugin-related questions right here.
+-->
 
+プラグイン開発者ハンドブックは WordPress プラグインに関するすべてのリソースです。WordPress プラグイン開発の初心者であろうと、経験豊富なプラグイン開発者であろうと、プラグインに関する多くの疑問に対する答えをここで見つけることができるはずです。
+
+<!--
 - If you're new to plugin development, start by reading the [introduction](https://developer.wordpress.org/plugins/intro/) and then move on to [the basics](https://developer.wordpress.org/plugins/plugin-basics/).
 - The info in [plugin security](https://developer.wordpress.org/apis/security/) will introduce best practices for security related stuff.
 - [Hooks](https://developer.wordpress.org/plugins/hooks/) are what make your plugin interact with WordPress, and how you can let other developers interact with your plugin.
@@ -15,5 +28,22 @@ The Plugin Developer Handbook is a resource for all things WordPress plugins. Wh
 - [Internationalization](https://developer.wordpress.org/plugins/internationalization/) is how you get your plugin ready for use in locales other than your own.
 - When all that is done, you can prepare your plugin for inclusion in the [Plugin Directory](https://developer.wordpress.org/plugins/wordpress-org/)
 - Finally: some [developer tools](https://developer.wordpress.org/plugins/developer-tools/) you might find useful.
+-->
 
+- プラグイン開発の初心者の方は、[プラグイン開発の紹介](https://developer.wordpress.org/plugins/intro/)を読んでから[基本](https://developer.wordpress.org/plugins/plugin-basics/)に進んでください。
+- [プラグインのセキュリティに関する情報](https://developer.wordpress.org/apis/security/)では、セキュリティ関連のベストプラクティスを紹介します。
+- [フック](https://developer.wordpress.org/plugins/hooks/)は、プラグインを WordPress と相互作用させるものであり、他の開発者があなたのプラグインと相互作用できるようにする方法です。
+- [プライバシー](https://developer.wordpress.org/plugins/privacy/)は、機密データの取り扱いについて理解するのに役立ちます。
+- プラグインで使用できる WordPress の組込み機能については、[管理メニュー](https://developer.wordpress.org/plugins/administration-menus/)、[ショートコード](https://developer.wordpress.org/plugins/shortcodes/)、[設定](https://developer.wordpress.org/plugins/settings/)、[メタデータ](https://developer.wordpress.org/plugins/metadata/)、[カスタム投稿タイプ](https://developer.wordpress.org/plugins/post-types/)、[タクソノミ](https://developer.wordpress.org/plugins/taxonomies/)、[ユーザー](https://developer.wordpress.org/plugins/users/)をご覧ください。
+- [HTTP API](https://developer.wordpress.org/plugins/http-api/) を使用したデータ取得についてはこちらをご覧ください。
+- プラグインで [AJAX](https://developer.wordpress.org/plugins/javascript/) を使用している場合は、そのセクションで必要な情報を見つけることができます。
+- 時間ベースの WordPress タスクについて学ぶには [Cron](https://developer.wordpress.org/plugins/cron/) の章をご覧ください。
+- [国際化](https://developer.wordpress.org/plugins/internationalization/) は、あなたのプラグインをあなたのロケール以外で使用できるようにする方法です。
+- すべての作業が完了したら、プラグインを [Plugin ディレクトリ](https://developer.wordpress.org/plugins/wordpress-org/)に登録する準備をします。
+- 最後に: 役に立つかもしれない、いくつかの[開発者ツール](https://developer.wordpress.org/plugins/developer-tools/)を紹介します。
+
+<!--
 The WordPress Plugin Developer Handbook is created by the WordPress community, for the WordPress community. We are always looking for more contributors; if you're interested, stop by the [Docs Team blog](https://make.wordpress.org/docs/) to find out more about getting involved.
+-->
+
+WordPress プラグイン開発者ハンドブックは WordPress コミュニティによって WordPress コミュニティのために作成されています。私たちは、常により多くの貢献者を探しています。ご興味があれば、[Docs Team blog](https://make.wordpress.org/docs/) をご覧ください。

--- a/intro/index.md
+++ b/intro/index.md
@@ -1,13 +1,41 @@
+<!--
 # Introduction to Plugin Development
+-->
 
+# プラグイン開発の紹介
+
+<!--
 Welcome to the Plugin Developer Handbook. Whether you're writing your first plugin or your fiftieth, we hope this resource helps you write the best plugin possible.
+-->
 
+プラグイン開発者ハンドブックへようこそ。初めてプラグインを書くのであれ、50個目のプラグインを書くのであれ、このリソースが可能な限り最高のプラグインを書く助けになることを願っています。
+
+<!--
 The Plugin Developer Handbook covers a variety of topics — everything from what should be in the plugin header, to security best practices, to tools you can use to build your plugin. It's also a work in progress — if you find something missing or incomplete, please notify the documentation team in slack and we'll make it better together.
+-->
 
+プラグイン開発者ハンドブックでは、さまざまなトピックを扱います。プラグインのヘッダーに書くべき内容から、セキュリティのベストプラクティス、プラグインを構築するために使用するツールまで、あらゆるトピックを扱います。もし足りないものや不完全なものを見つけたら、slack でドキュメントチームに知らせてください。
+
+<!--
 ## Why We Make Plugins
+-->
 
+## プラグインを作る理由
+
+<!--
 If there's one cardinal rule in WordPress development, it's this: **Don't touch WordPress core**. This means that you don't edit core WordPress files to add functionality to your site. This is because WordPress overwrites core files with each update. Any functionality you want to add or modify should be done using plugins.
+-->
 
+WordPress の開発で基本的なルールが1つあるとすれば、それは **WordPress のコア部分には触らないこと** です。つまり、WordPress のコアファイルを編集して、サイトに機能を追加してはいけないということです。WordPress はアップデートのたびにコアファイルを上書きしてしまうからです。追加したい機能や修正したい機能は、プラグインを使用して行う必要があります。
+
+<!--
 WordPress plugins can be as simple or as complicated as you need them to be, depending on what you want to do. The simplest plugin is a single PHP file. The [Hello Dolly](https://wordpress.org/plugins/hello-dolly/ "Hello Dolly Plugin") plugin is an example of such a plugin. The plugin PHP file just needs a [Plugin Header](https://developer.wordpress.org/plugins/plugin-basics/header-requirements/), a couple of PHP functions, and some [hooks](https://developer.wordpress.org/plugins/hooks/) to attach your functions to.
+-->
 
+WordPress のプラグインは、やりたいことに応じて、簡単なものから複雑なものまで作ることができます。最もシンプルなプラグインは、単一の PHP ファイルです。[Hello Dolly](https://wordpress.org/plugins/hello-dolly/ "Hello Dolly Plugin") プラグインはそのようなプラグインの例です。プラグインの PHP ファイルは、[プラグインヘッダー](https://developer.wordpress.org/plugins/plugin-basics/header-requirements/) といくつかの PHP 関数、そして関数をアタッチするための[フック](https://developer.wordpress.org/plugins/hooks/) が必要なだけです。
+
+<!--
 Plugins allow you to greatly extend the functionality of WordPress without touching WordPress core itself.
+-->
+
+プラグインは、WordPress のコアそのものに触れることなく、WordPress の機能を大幅に拡張できます。

--- a/intro/what-is-a-plugin/index.md
+++ b/intro/what-is-a-plugin/index.md
@@ -1,13 +1,40 @@
+<!--
 # What is a Plugin?
+-->
 
+# プラグインとは何ですか ?
+
+<!--
 Plugins are packages of code that extend the core functionality of WordPress. WordPress plugins are made up of PHP code and can include other assets such as images, CSS, and JavaScript.
+-->
 
+プラグインは、WordPress のコア機能を拡張するコードのパッケージです。WordPress のプラグインは PHP コードで構成されており、画像、CSS、JavaScript などの他のアセットを含めることができます。
+
+<!--
 By making your own plugin you are _extending_ WordPress, for example, building additional functionality on top of what WordPress already offers, or you could write a plugin that displays links to the ten most recent posts on your site.
+-->
 
+プラグインを作成することは、WordPress を「拡張」することです。たとえば、WordPress がすでに提供している機能の上にさらに機能を追加したり、サイトの最新の10記事へのリンクを表示するプラグインを作成できます。
+
+
+<!--
 Or, using WordPress' custom post types, you could write a plugin that creates a full-featured support ticketing system with email notifications, custom ticket statuses, and a client-facing portal. The possibilities are _endless_!_
+-->
 
+あるいは、WordPress のカスタム投稿タイプを使用して、電子メール通知、カスタムチケットステータス、および顧客向けポータルを備えたフル機能のサポートチケットシステムを作成するプラグインを作成することも可能です。可能性は無限大です !
+
+<!--
 Most WordPress plugins are composed of many files, but a plugin really only _needs_ one main file with a specifically formatted [DocBlock](https://en.wikipedia.org/wiki/PHPDoc) in the header.
+-->
+
+WordPress のプラグインは多くのファイルで構成されていますが、プラグインとして認識されるために本当に必要なのは、ヘッダーに特別な書式の [DocBlock](https://en.wikipedia.org/wiki/PHPDoc) を持つ1つのメインファイルだけです。
 
 [Hello Dolly](https://wordpress.org/plugins/hello-dolly/ "Hello Dolly"), one of the first plugins, is only [100 lines](https://plugins.trac.wordpress.org/browser/hello-dolly/trunk/hello.php) long. Hello Dolly shows lyrics from [the famous song](https://en.wikipedia.org/wiki/Hello,_Dolly!_(song)) in the WordPress admin. Some CSS is used in the PHP file to control how the lyric is styled.
 
+最初のプラグインの一つである [Hello Dolly](https://wordpress.org/plugins/hello-dolly/ "Hello Dolly") は、わずか[100行](https://plugins.trac.wordpress.org/browser/hello-dolly/trunk/hello.php)の長さです。Hello Dolly は、WordPress の 管理画面に[有名な曲](https://en.wikipedia.org/wiki/Hello,_Dolly!_(song))の歌詞を表示します。その PHP ファイルには、歌詞のスタイルを制御するためにいくつかの CSS が使用されています。
+
+<!--
 As a WordPress.org plugin author, you have an amazing opportunity to create a plugin that will be installed, tinkered with, and loved by millions of WordPress users. All **you** need to do is turn your great idea into code. The Plugin Handbook is here to help you with that.
+-->
+
+WordPress.org のプラグイン作者として、何百万人もの WordPress ユーザーにインストールされ、いじられ、愛されるプラグインを作成するすばらしい機会があります。**あなた**がすべきことは、あなたのすばらしいアイデアをコードにすることです。プラグインハンドブックは、そのお手伝いをするためにあります。

--- a/javascript/index.md
+++ b/javascript/index.md
@@ -1,3 +1,11 @@
+<!--
+# JavaScript
+-->
+
 # JavaScript
 
+<!--
 JavaScript is an important component in many WordPress plugins.  WordPress comes with a [variety of JavaScript libraries bundled with core](https://developer.wordpress.org/themes/basics/including-css-javascript/#default-scripts-included-and-registered-by-wordpress). One of the most commonly-used libraries in WordPress is jQuery because it is lightweight and easy to use. jQuery can be used in your plugin to manipulate the DOM object or to perform Ajax actions.
+-->
+
+JavaScript は、多くの WordPress プラグインで重要なコンポーネントです。WordPress には[コアにバンドルされた様々な JavaScript ライブラリ](https://developer.wordpress.org/themes/basics/including-css-javascript/#default-scripts-included-and-registered-by-wordpress)が付属しています。WordPress で最もよく使われるライブラリの一つは jQuery で、軽量で使い易いからです。jQuery は、DOM オブジェクトを操作したり、Ajax アクションを実行するためにプラグインで使用できます。

--- a/metadata/index.md
+++ b/metadata/index.md
@@ -1,8 +1,24 @@
 
+<!--
 # Metadata
+-->
 
+# メタデータ
+
+<!--
 Metadata is information about information. In the case of WordPress, it's information associated with posts, users, comments and terms.
+-->
 
+メタデータとは、情報についての情報です。WordPress の場合、投稿、ユーザー、コメント、タームに関連する情報です。
+
+<!--
 Given the many-to-one relationship of metadata in WordPress, your options are fairly limitless. You can have as many meta options as you wish, and you can store just about anything in there.
+-->
 
+WordPress におけるメタデータの多対一の関係を考えると、オプションはかなり無限大です。望むだけ多くのメタオプションを持つことができ、そこにあらゆるものを保存できます。
+
+<!--
 This chapter will discuss [managing post metadata](https://developer.wordpress.org/plugins/metadata/managing-post-metadata/), [creating custom meta boxes](https://developer.wordpress.org/plugins/metadata/custom-meta-boxes/), and [rendering post metadata](https://developer.wordpress.org/plugins/metadata/rendering-post-metadata/).
+-->
+
+この章では、[投稿メタデータの管理](https://developer.wordpress.org/plugins/metadata/managing-post-metadata/)、[カスタムメタボックスの作成](https://developer.wordpress.org/plugins/metadata/custom-meta-boxes/)、[投稿メタデータのレンダリング](https://developer.wordpress.org/plugins/metadata/rendering-post-metadata/)について説明します。

--- a/plugin-basics/index.md
+++ b/plugin-basics/index.md
@@ -1,18 +1,47 @@
+<!--
 # Plugin Basics
+-->
 
+# プラグインの基本
+
+
+<!--
 ## Getting Started
+-->
 
+## はじめに
+
+<!--
 At its simplest, a WordPress plugin is a PHP file with a WordPress plugin header comment. It's highly recommended that you create a directory to hold your plugin so that all of your plugin's files are neatly organized in one place.
+-->
 
+端的に言えば、WordPress プラグインは、WordPress プラグインヘッダーコメントを持つ PHP ファイルです。プラグインを保存するディレクトリを作成し、プラグインのすべてのファイルを一ヵ所にきちんとまとめることを強くおすすめします。
+
+<!--
 To get started creating a new plugin, follow the steps below.
+-->
 
+新しいプラグインの作成を始めるには、以下の手順に従ってください。
+
+<!--
 1. Navigate to the WordPress installation's `wp-content/` directory.
 2. Open the `plugins/` directory.
 3. Create a new directory and name it after the plugin (e.g. `plugin-name/`).
 4. Open the new plugin's directory.
 5. Create a new PHP file (it's also good to name this file after your plugin, e.g. `plugin-name.php`).
+-->
 
+1. WordPress の `wp-content/` ディレクトリに移動します。
+2. `plugins/` ディレクトリを開きます。
+3. 新しいディレクトリを作成し、プラグインの名前を付けます (例: `plugin-name/`)。
+4. 新しいプラグインのディレクトリを開きます。
+5. 新しい PHP ファイルを作成します (このファイルにも、`plugin-name.php` などのプラグインの名前を付けるとよいでしょう)。
+
+<!--
 Here's what the process looks like on the Unix command line:
+-->
+
+Unix のコマンドラインでは次のようになります:
 
 ```bash
 $ cd wp-content/
@@ -22,56 +51,164 @@ $ cd plugin-name/
 $ vim plugin-name.php
 ```
 
+<!--
 In the example above, `vim` is the name of the text editor. Use whichever editor that is comfortable for you.
+-->
 
+上の例では、`vim` はテキストエディターの名前です。あなたが使いやすいエディターを使用してください。
+
+<!--
 Now that you're editing your new plugin's PHP file, you'll need to add a plugin header comment. This is a specially formatted PHP block comment that contains metadata about the plugin, such as its name, author, version, license, etc. The plugin header comment must comply with the [header requirements](https://developer.wordpress.org/plugins/plugin-basics/header-requirements/), and at the very least, contain the name of the plugin.
+-->
 
+新しいプラグインの PHP ファイルを編集しているので、プラグインヘッダーコメントを追加する必要があります。これは特別な書式の PHP ブロックコメントで、プラグインの名前、作者、バージョン、ライセンスなどのメタデータを含みます。プラグインヘッダーコメントは[ヘッダー要件](https://developer.wordpress.org/plugins/plugin-basics/header-requirements/)に従わなければならず、最低限プラグインの名前を含まなければなりません。
+
+<!--
 Only one file in the plugin's folder should have the header comment — if the plugin has multiple PHP files, only one of those files should have the header comment.
+-->
 
+プラグインのフォルダー内の1つのファイルだけがヘッダーコメントを持つようにします - プラグインに複数の PHP ファイルがある場合は、そのうちの1つのファイルだけがヘッダーコメントを持つようにします。
+
+<!--
 After you save the file, you should be able to see your plugin listed in your WordPress site. Log in to your WordPress site, and click **Plugins** on the left navigation pane of your WordPress Admin. This page displays a listing of all the plugins your WordPress site has. Your new plugin should now be in that list!
+-->
 
+ファイルを保存すると、WordPress サイトにプラグインが表示されるはずです。WordPress サイトにログインし、WordPress 管理画面の左側のナビゲーションペインにある**プラグイン**をクリックします。このページには、WordPress サイトにあるすべてのプラグインのリストが表示されます。新しいプラグインはこのリストにあるはずです !
+
+<!--
 ## Hooks: Actions and Filters
+-->
 
+## フック: アクションとフィルター
+
+<!--
 WordPress hooks allow you to tap into WordPress at specific points to change how WordPress behaves without editing any core files.
+-->
 
+WordPress のフックを使うと、コアファイルを編集することなく特定のポイントで WordPress の動作を変更できます。
+
+<!--
 There are two types of hooks within WordPress: _actions_ and _filters_. Actions allow you to add or change WordPress functionality, while filters allow you to alter content as it is loaded and displayed to the website user.
+-->
 
+WordPress のフックには、「アクション」と「フィルター」の2種類があります。アクションは、WordPress の機能を追加または変更でき、フィルターはそれがロードされ、Web サイトのユーザーに表示されるようにコンテンツを変更できます。
+
+<!--
 Hooks are not just for plugin developers; hooks are used extensively to provide default functionality by WordPress core itself. Other hooks are unused place holders that are simply available for you to tap into when you need to alter how WordPress works. This is what makes WordPress so flexible.
+-->
 
+フックはプラグイン開発者だけのものではなく、WordPress のコア自体がデフォルトの機能を提供するために広く使われています。他のフックは未使用のプレースホルダーで、WordPress の動作を変更する必要があるときに利用できます。これが WordPress の柔軟性を高めているのです。
+
+<!--
 ### Basic Hooks
+-->
 
+### 基本的なフック
+
+<!--
 The 3 basic hooks you'll need when creating a plugin are the [register\_activation\_hook()](https://developer.wordpress.org/reference/functions/register_activation_hook/), the [register\_deactivation\_hook()](https://developer.wordpress.org/reference/functions/register_deactivation_hook/), and the [register\_uninstall\_hook()](https://developer.wordpress.org/reference/functions/register_uninstall_hook/).
+-->
 
+プラグインを作成するときに必要な3つの基本フックは、[register\_activation\_hook()](https://developer.wordpress.org/reference/functions/register_activation_hook/)、[register\_deactivation\_hook()](https://developer.wordpress.org/reference/functions/register_deactivation_hook/)、および [register\_uninstall\_hook()](https://developer.wordpress.org/reference/functions/register_uninstall_hook/) です。
+
+<!--
 The [activation hook](https://developer.wordpress.org/plugins/plugin-basics/activation-deactivation-hooks/) is run when you _activate_ your plugin. You would use this to provide a function to set up your plugin — for example, creating some default settings in the `options` table.
+-->
 
+[アクティベーションフック](https://developer.wordpress.org/plugins/plugin-basics/activation-deactivation-hooks/)は、プラグインを**有効化**するときに実行されます。これを使用して、プラグインをセットアップする機能を提供します。たとえば、`options` テーブルにいくつかのデフォルト設定を作成します。
+
+<!--
 The [deactivation hook](https://developer.wordpress.org/plugins/plugin-basics/activation-deactivation-hooks/) is run when you _deactivate_ your plugin. You would use this to provide a function that clears any temporary data stored by your plugin.
+-->
 
+[非アクティブ化フック](https://developer.wordpress.org/plugins/plugin-basics/activation-deactivation-hooks/)は、プラグインを**無効化**すると実行されます。これを使用して、プラグインによって保存された一時データをクリアする関数を提供します。
+
+<!--
 These [uninstall methods](https://developer.wordpress.org/plugins/plugin-basics/uninstall-methods/) are used to clean up after your plugin is _deleted_ using the WordPress Admin. You would use this to delete all data created by your plugin, such as any options that were added to the `options` table.
+-->
 
+これらの[アンインストールメソッド](https://developer.wordpress.org/plugins/plugin-basics/uninstall-methods/)は、WordPress 管理画面を使用してプラグインが**削除**された後にクリーンアップするために使用されます。これを使用して、`options` テーブルに追加されたオプションなど、プラグインによって作成されたすべてのデータを削除します。
+
+<!--
 ### Adding Hooks
+-->
 
+### フックの追加
+
+<!--
 You can add your own, custom hooks with [do_action()](https://developer.wordpress.org/reference/functions/do_action/) , which will enable developers to extend your plugin by passing functions through your hooks.
+-->
 
+[do_action()](https://developer.wordpress.org/reference/functions/do_action/) を使用して独自のカスタムフックを追加できます。これにより、開発者はフックを介して関数を渡すことによってプラグインを拡張できます。
+
+<!--
 ### Removing Hooks
+-->
 
+### フックの削除
+
+<!--
 You can also use invoke [remove_action()](https://developer.wordpress.org/reference/functions/remove_action/) to remove a function that was defined earlier. For example, if your plugin is an add-on to another plugin, you can use [remove_action()](https://developer.wordpress.org/reference/functions/remove_action/) with the same function callback that was added by the previous plugin with [add_action()](https://developer.wordpress.org/reference/functions/add_action/). The priority of actions is important in these situations, as [remove_action()](https://developer.wordpress.org/reference/functions/remove_action/) would need to run after the initial [add_action()](https://developer.wordpress.org/reference/functions/add_action/).
+-->
 
+[remove_action()](https://developer.wordpress.org/reference/functions/remove_action/) を使用して、先に定義された関数を削除することもできます。たとえば、プラグインが別のプラグインのアドオンである場合、前のプラグインの [add_action()](https://developer.wordpress.org/reference/functions/add_action/) によって追加された関数コールバックと同じものを [remove_action()](https://developer.wordpress.org/reference/functions/remove_action/) で削除できます。[remove_action()](https://developer.wordpress.org/reference/functions/remove_action/) は最初の [add_action()](https://developer.wordpress.org/reference/functions/add_action/) の後に実行する必要があるため、このような状況ではアクションの優先順位が重要です。
+
+<!--
 You should be careful when removing an action from a hook, as well as when altering priorities, because it can be difficult to see how these changes will affect other interactions with the same hook. We highly recommend testing frequently.
+-->
 
+フックからアクションを削除するときや優先順位を変更するときは注意が必要です。これらの変更が同じフックとの他の相互作用にどのような影響を与えるかを確認するのが難しい場合があるためです。頻繁にテストすることを強くおすすめします。
+
+<!--
 You can learn more about creating hooks and interacting with them in the [Hooks](https://developer.wordpress.org/plugins/hooks/) section of this handbook.
+-->
 
+フックの作成とその操作について詳しくは、このハンドブックの[フック](https://developer.wordpress.org/plugins/hooks/)セクションをご覧ください。
+
+<!--
 ## WordPress APIs
+-->
 
+## WordPress API
+
+<!--
 Did you know that WordPress provides a number of [Application Programming Interfaces (APIs)](https://make.wordpress.org/core/handbook/best-practices/core-apis/)? These APIs can greatly simplify the code you need to write in your plugins. You don't want to reinvent the wheel, especially when so many people have done a lot of the work and testing for you.
+-->
 
+WordPress が多数の[アプリケーションプログラミングインターフェイス (API)](https://make.wordpress.org/core/handbook/best-practices/core-apis/) を提供していることをご存じですか ? これらの API を使用すると、プラグインで記述する必要があるコードを大幅に簡素化できます。特に多くの人があなたのために多くの作業やテストを行ってくれた場合には、車輪の再発明はしたくないでしょう。
+
+<!--
 The most common one is the [Options API](https://codex.wordpress.org/Options_API), which makes it easy to store data in the database for your plugin. If you're thinking of using [cURL](https://en.wikipedia.org/wiki/CURL) in your plugin, the [HTTP API](https://developer.wordpress.org/plugins/http-api/) might be of interest to you.
+-->
 
+最も一般的なのは [Options API](https://codex.wordpress.org/Options_API) で、これを使用すると、プラグインのデータをデータベースに簡単に保存できます。プラグインで [cURL](https://en.wikipedia.org/wiki/CURL) を使用することを考えている場合、[HTTP API](https://developer.wordpress.org/plugins/http-api/) は役に立つでしょう。
+
+<!--
 Since we're talking about plugins, you'll want to study the [Plugin API](https://codex.wordpress.org/Plugin_API). It has a variety of functions that will assist you in developing plugins.
+-->
 
+ここではプラグインについて話しているので、[プラグイン API](https://codex.wordpress.org/Plugin_API) について学んでください。プラグインの開発を支援するさまざまな機能が備わっています。
+
+<!--
 ## How WordPress Loads Plugins
+-->
 
+## WordPress がプラグインをロードする方法
+
+<!--
 When WordPress loads the list of installed plugins on the Plugins page of the WordPress Admin, it searches through the `plugins/` folder (and its sub-folders) to find PHP files with WordPress plugin header comments. If your entire plugin consists of just a single PHP file, like [Hello Dolly](https://wordpress.org/plugins/hello-dolly/ "Hello Dolly"), the file could be located directly inside the root of the `plugins/` folder. But more commonly, plugin files will reside in their own folder, named after the plugin.
+-->
 
+WordPress が WordPress 管理画面のプラグインページでインストールされているプラグインのリストを読み込むとき、`plugins/` フォルダー (およびそのサブフォルダー) を検索して、WordPress プラグインヘッダーコメントを含む PHP ファイルを見つけます。[Hello Dolly](https://wordpress.org/plugins/hello-dolly/ "Hello Dolly") のように、プラグイン全体が1つの PHP ファイルのみで構成されている場合、ファイルは `plugins/` フォルダーのルート内に直接配置できます。ただし一般的には、プラグインファイルは、プラグインにちなんで名付けられた独自のフォルダーに存在します。
+
+<!--
 ## Sharing your Plugin
+-->
 
+## プラグインを共有する
+
+<!--
 Sometimes a plugin you create is just for your site. But many people like to share their plugins with the rest of the WordPress community. Before sharing your plugin, one thing you need to do is [choose a license](https://choosealicense.com/). This lets the user of your plugin know how they are allowed to use your code. To maintain compatibility with WordPress core, it is recommended that you pick a license that works with GNU General Public License (GPLv2+).
+-->
+
+作成したプラグインがサイト専用である場合があります。しかし、多くの人は自分のプラグインを WordPress コミュニティの他のメンバーと共有したいと考えています。プラグインを共有する前に、[ライセンスを選択](https://choosealicense.com/)する必要があります。これにより、プラグインのユーザーはコードの使用がどのように許可されているかを知ることができます。WordPress コアとの互換性を維持するには、GNU General Public License (GPLv2+) で動作するライセンスを選択することをおすすめします。

--- a/post-types/index.md
+++ b/post-types/index.md
@@ -1,5 +1,17 @@
+<!--
 # Custom Post Types
+-->
 
+# カスタム投稿タイプ
+
+<!--
 WordPress stores the Post Types in the `posts` table allowing developers to register Custom Post Types along the ones that already exist.
+-->
 
+WordPress は投稿タイプを `posts` テーブルに保存しており、開発者はすでに存在する投稿タイプに加え、カスタム投稿タイプを登録できます。
+
+<!--
 This chapter will show you how to [register Custom Post Types](https://developer.wordpress.org/plugins/post-types/registering-custom-post-types/), how to [retrieve their content from the database, and how to render them to the public](https://developer.wordpress.org/plugins/post-types/working-with-custom-post-types/).
+-->
+
+この章では、[カスタム投稿タイプの登録方法](https://developer.wordpress.org/plugins/post-types/registering-custom-post-types/)、[データベースからコンテンツを取得する方法と公開する方法](https://developer.wordpress.org/plugins/post-types/working-with-custom-post-types/)について説明します。

--- a/security/index.md
+++ b/security/index.md
@@ -1,5 +1,15 @@
+<!--
 # Plugin Security
+-->
 
+# プラグインのセキュリティ
+
+<!--
 This content has been moved to the [Security page](https://developer.wordpress.org/apis/security/) in the Common APIs Handbook.
+-->
 
+このコンテンツは、共通 API ハンドブックの[セキュリティページ](https://developer.wordpress.org/apis/security/)に移動しました。
+
+<!--
 But there is more content to read...
+-->

--- a/settings/index.md
+++ b/settings/index.md
@@ -1,11 +1,35 @@
+<!--
 # Settings
+-->
 
+# 設定
+
+<!--
 WordPress provides two core APIs to make the administrative interfaces easy to build, secure, and consistent with the design of WordPress Administration.
+-->
 
+WordPress は、管理インターフェースを簡単に構築でき、安全で、WordPress の管理設計と一貫したものにするために、2つのコア API を提供しています。
+
+<!--
 The [Settings API](https://developer.wordpress.org/plugins/settings/settings-api/) focuses on providing a way for developers to create forms and manage form data.
+-->
 
+[設定 API](https://developer.wordpress.org/plugins/settings/settings-api/) は、開発者がフォームを作成し、フォームデータを管理する方法を提供することに重点を置いています。
+
+<!--
 The [Options API](https://developer.wordpress.org/plugins/settings/options-api/) focuses on managing data using a simple key/value system.
+-->
 
+[オプション API](https://developer.wordpress.org/plugins/settings/options-api/) は、シンプルなキー/バリュー・システムを使ったデータ管理に重点を置いています。
+
+<!--
 ## Quick Reference
+-->
 
+## クイックリファレンス
+
+<!--
 See the complete example of [building a custom settings page](https://developer.wordpress.org/plugins/settings/custom-settings-page/) using the Settings API and Options API.
+-->
+
+設定 API とオプション API を使用した[カスタム設定ページの構築](https://developer.wordpress.org/plugins/settings/custom-settings-page/)の完全な例を参照してください。

--- a/taxonomies/index.md
+++ b/taxonomies/index.md
@@ -1,13 +1,41 @@
+<!--
 ## Taxonomies
+-->
 
+# タクソノミー
+
+<!--
 A **Taxonomy** is a fancy word for the classification/grouping of things. Taxonomies can be hierarchical (with parents/children) or flat.
+-->
 
+**タクソノミー**とは、物事を分類/グループ化するための専門用語です。タクソノミーは、階層的 (親/子) にもフラットにもなります。
+
+<!--
 WordPress stores the Taxonomies in the `term_taxonomy` database table allowing developers to register Custom Taxonomies along the ones that already exist.
+-->
 
+WordPress は `term_taxonomy` データベース・テーブルにタクソノミーを格納し、開発者はすでに存在するタクソノミーの他に、カスタム・タクソノミーを登録できます。
+
+<!--
 Taxonomies have **Terms** which serve as the topic by which you classify/group things. They are stored inside the `terms` table.
+-->
 
+タクソノミーには**ターム**があり、トピックとして分類/グループ化されます。これらは `terms` テーブルに格納されます。
+
+<!--
 For example: a Taxonomy named "Art" can have multiple Terms, such as "Modern" and "18th Century".
+-->
 
+たとえば: "Art" という名前のタクソノミーは、"Modern" や "18th Century" といった複数のタームを持つことができます。
+
+<!--
 This chapter will show you how to register Custom Taxonomies, how to retrieve their content from the database, and how to render them to the public.
+-->
 
+この章では、カスタムタクソノミーの登録方法、データベースからの取得方法、公開方法について説明します。
+
+<!--
 [info]WordPress 3.4 and earlier had a Taxonomy named "Links" which was deprecated in WordPress 3.5.[/info]
+-->
+
+[info]WordPress 3.4 以前には "Links" というタクソノミーがありましたが、WordPress 3.5 では廃止されました。[/info]


### PR DESCRIPTION
旧日本語版リポジトリ（[plugin-handbook](https://github.com/jawordpressorg/plugin-handbook)）で翻訳済のページを、当リポジトリに反映します。