### PR TITLE
翻訳: developer-tools/helper-plugins/index.md

### DIFF
--- a/developer-tools/helper-plugins/index.md
+++ b/developer-tools/helper-plugins/index.md
@@ -5,11 +5,23 @@
 
 ## Plugin Check
 
+<!--
 Plugin Check is a tool for testing whether your plugin meets the required standards for the WordPress.org plugin directory. With this plugin you will be able to run most of the checks used for new submissions, and check if your plugin meets the requirements.
+-->
 
+Plugin Check は、プラグインが WordPress.org プラグインディレクトリの必須基準を満たしているかどうかをテストするためのツールです。このプラグインを使用すると、新しい提出に使用されるほとんどのチェックを実行し、プラグインが要件を満たしているかどうかを確認できます。
+
+<!--
 Additionally, the tool flags violations or concerns around plugin development best practices, from basic requirements like correct usage of internationalization functions to accessibility, performance, and security best practices.
+-->
 
+さらにこのツールは、国際化機能の正しい使用法などの基本要件から、アクセシビリティ、パフォーマンス、セキュリティのベストプラクティスまで、プラグイン開発のベストプラクティスに関する違反や懸念事項をフラグ付けします。
+
+<!--
 [Visit Plugin Check](https://wordpress.org/plugins/plugin-check/)
+-->
+
+[Plugin Check を見る](https://wordpress.org/plugins/plugin-check/)
 
 ## Query Monitor
 


### PR DESCRIPTION
原文との同期（[8772281](https://github.com/jawordpressorg/developer-plugins-handbook/commit/8772281ff2275e15b670244f9f01e4c98d82feb0) ）によって発生した追加テキストを翻訳しました。

二文だけのため、このままマージします。