### PR TITLE
users/working-with-user-metadata/index.md: 原文の重複を削除

### DIFF
--- a/users/working-with-user-metadata/index.md
+++ b/users/working-with-user-metadata/index.md
@@ -236,8 +236,6 @@ Please refer to the Function Reference about [`update_user_meta()`](https://deve
  -->
 #### 削除
 
-#### Delete
-
 ```
 delete_user_meta(
   int $user_id,


### PR DESCRIPTION
4dd6fc2 で原文と同期したときに、誤って原文の重複が一か所でてしまったため、修正。