### PR TITLE
fixes #218 wordpress-org/using-the-forums/index.md 和訳しました。

### DIFF
--- a/wordpress-org/using-the-forums/index.md
+++ b/wordpress-org/using-the-forums/index.md
@@ -134,7 +134,7 @@ The real issue here is that users don’t like talking to “MarvelTech100” as
 <!-- 
 That said, having a company account to own your plugin is perfectly logical and reasonable. However in those situations, the account is only intended to be the **owner** of the plugins/themes, and is **not** permitted to use the forums.
  -->
-とはいえ、プラグインを所有するために企業アカウントを持つことは完全に論理的で合理的です。しかし、そのような状況では、そのアカウントはプラグイン/テーマの **所有者** であることを意図しているだけであり、フォーラムを使用することは「¥許可 **されていません**。
+とはいえ、プラグインを所有するために企業アカウントを持つことは完全に論理的で合理的です。しかし、そのような状況では、そのアカウントはプラグイン/テーマの **所有者** であることを意図しているだけであり、フォーラムを使用することは「許可 **されていません**。
 
 <!-- 
 If you want to have two accounts, where one is your personal account and the other is “You at the company” that’s totally fine. People just prefer talking to people.

--- a/wordpress-org/using-the-forums/index.md
+++ b/wordpress-org/using-the-forums/index.md
@@ -134,7 +134,7 @@ The real issue here is that users don’t like talking to “MarvelTech100” as
 <!-- 
 That said, having a company account to own your plugin is perfectly logical and reasonable. However in those situations, the account is only intended to be the **owner** of the plugins/themes, and is **not** permitted to use the forums.
  -->
-とはいえ、プラグインを所有するために企業アカウントを持つことは完全に論理的で合理的です。しかし、そのような状況では、そのアカウントはプラグイン/テーマの **所有者** であることを意図しているだけであり、フォーラムを使用することは「許可 **されていません**。
+とはいえ、プラグインを所有するために企業アカウントを持つことは完全に論理的で合理的です。しかし、そのような状況では、そのアカウントはプラグイン/テーマの **所有者** であることを意図しているだけであり、フォーラムを使用することは許可 **されていません**。
 
 <!-- 
 If you want to have two accounts, where one is your personal account and the other is “You at the company” that’s totally fine. People just prefer talking to people.

--- a/wordpress-org/using-the-forums/index.md
+++ b/wordpress-org/using-the-forums/index.md
@@ -1,61 +1,152 @@
+<!-- 
 # Using the Forums
+ -->
+# フォーラムの利用
 
+<!-- 
 With the free plugin hosting, all plugin developers are given access to use the support forums and the reviews to help manage their plugins.
+ -->
+無料のプラグイン・ホスティングでは、すべてのプラグイン開発者がサポートフォーラムやレビューを利用でき、プラグインの管理に役立ちます。
 
+<!-- 
 Developers are required to comply with the [forum guidelines](https://wordpress.org/support/guidelines/) while using the forums, which can lead to some confusion about how to manage premium versions of plugins.
+ -->
+開発者はフォーラムを利用する際、[フォーラム・ガイドライン](https://wordpress.org/support/guidelines/)を遵守する必要があり、プレミアム版プラグインの管理方法について混乱が生じる可能性があります。
 
+<!-- 
 ## The guidelines apply to everyone
+ -->
+## ガイドラインは、すべての人に適用される
 
+<!-- 
 The plugin owner is the ultimate controller of the plugin. However, if the other developers or support reps violate the guideline, the plugin is at risk for censure and closure. It is not the responsibility of the forum or plugin teams to manage your company/employees. If a support rep is making sock puppets, the plugin developers will be notified and expected to take action. If they cannot, or will not, restrain their coworkers, we will cease to host their plugins and may ban the company.
+ -->
+プラグイン所有者は、プラグインの最終的な管理者です。しかし、他の開発者やサポート担当がガイドラインに違反した場合、そのプラグインは問責とクローズのリスクにさらされます。あなたの会社や従業員を管理するのは、フォーラムやプラグイン・チームの責務ではありません。サポート担当が多重アカウントを作っている場合、プラグイン開発者に通知され、対策を講じることが期待されます。彼らが同僚を説得できない、あるいは説得しようとしない場合、私たちは彼らのプラグインのホスティングを中止し、その会社を追放することも考えられます。
 
+<!-- 
 **_Everyone_** has to abide by the guidelines. No exceptions.
+ -->
+**_誰もが_** ガイドラインを遵守することが求められます。例外はありません。
 
+<!-- 
 ## The directory is not a marketplace
+ -->
+## ディレクトリは、マーケットプレイスではない
 
+<!-- 
 The plugin directory and forums are not for you to sell or support products that are not hosted here. If the only reason you have a plugin in our systems is for your business promotion, you must understand that there are no special considerations granted to anyone for that.
+ -->
+プラグインディレクトリとフォーラムは、ここでホストされていない製品を販売したりサポートしたりするためのものではありません。私たちのシステム上にプラグインを持っている唯一の理由が、あなたのビジネスプロモーションのためである場合、そのために誰にでも与えられる特別な配慮がないことを、あなたは理解しなければなりません。
 
+<!-- 
 ## Users are not customers
+ -->
+## ユーザーは、顧客ではない
 
+<!-- 
 Users on WordPress.org are not your customers and should be treated as users. This means you _cannot_ ask them for private contact information, you cannot offer to log in to their site, and you cannot charge them for help. It is for your own legal protection, we prohibit those things. Even with the contract of a purchase, you are liable for damages caused by your logging into their site. Doing so without the purchase makes it more dangerous.
+ -->
+WordPress. org 上のユーザーは、あなたの顧客ではなく、ユーザーとして扱われるべきです。つまり、個人的な連絡先を聞いたり、サイトへのログインを勧めたり、ヘルプに対して料金を請求したりすることは _できません_。これはあなた自身の法的保護のためであり、私たちはそれらのことを禁止しています。たとえ購入という契約があったとしても、あなたが相手のサイトにログインしたことによって生じた損害については、あなたが責任を負うことになります。購入契約を結んでいない場合は、より危険です。
 
+<!-- 
 If someone is a customer (that is they purchased your premium offering and posted in the free forums), you can and should remind them that you cannot support them in the WordPress.org forums, and provide a link to your professional support services. Similarly, you can tell people that you aren’t able to offer free support in the forums and link to your site where you can explain in full detail.
+ -->
+もし誰かが (あなたのプレミアム製品を購入し、無償のフォーラムに投稿した) 顧客であれば、WordPress.org のフォーラムではサポートできないことを伝え、専門的なサポートサービスへのリンクを提供できますし、そうすべきです。同様に、フォーラムにおいて無償サポートを提供できないことを伝え、詳細について説明できるあなたのサイトへのリンクを提供できます。
 
+<!-- 
 ## You may request users open tickets on your own system
+ -->
+## あなたは、あなたのシステムで、ユーザーにチケットの発行を要求できる
 
+<!-- 
 This is especially true if you have a service that requires an account. There is already a pre-existing relationship with the user, and asking them to open a ticket for support of services is reasonable and permitted. You may also ask them to open a ticket if they’re an actual paying customer.
+ -->
+アカウントが要求されるサービスの場合は、特にそうです。ユーザーとはすでに既存の関係があり、サービスのサポートのためにチケットを開いてもらうことは合理的であり、許可されています。ユーザーとはすでに既存の関係があり、サービスのサポートのためにチケットを開いてもらうことは合理的であり、許可されています。
 
+<!-- 
 If you want to offer a higher level of support as a service (i.e. something they pay for), it’s acceptable to tell users that they have reached the limit of what you can support for free. In those situations, we recommend you have this disclosed in your readme with a dedicated page on your site to explain in detail what is and is not available for free help.
+ -->
+あなたが、より高いレベルのサポートをサービスとして提供したいのであれば (つまり、彼らがお金を払うもの)、あなたが無償でサポートできる限界に達していることをユーザーに伝えてもかまいません。そのような場合は、Readme でこのことを開示し、あなたのサイトに専用のページを設けて、無償のヘルプで利用できるものとできないものについて詳しく説明することをおすすめします。
 
+<!-- 
 For everyone else, if you’re helping people in the free forums, you are expected to help them _in_ the forums.
+ -->
+それ以外の皆さんは、無償フォーラムで人助けをするのであれば、フォーラム _内で_ 人助けをすることが求められます。
 
+<!-- 
 ## You are not required to offer free support
+ -->
+## あなたは、無償サポートを提供する必要はない
 
+<!-- 
 If you don’t want to offer free support, you don’t have to. We strongly recommend you make that clear in your readme (preferably at the top of the description so its hard to miss), and we will back you up on this.
+ -->
+もし無償サポートを提供したくないのであれば、その必要はありません。Readme に (見落としにくいように、できれば説明文の一番上に) その旨を明記することを強くおすすめしますし、私たちはあなたをバックアップします。
 
+<!-- 
 Keep in mind, people leaving you bad reviews because of that won’t be removed. You can reply to the reviews and explain why you don’t offer support, of course, and that you did disclose that fact.
+ -->
+そのために悪いレビューを残した人が削除されることはないことを覚えておいてください。もちろん、そのレビューに返信し、なぜサポートを提供しないのか、そしてその事実を公表したことを説明できます。
 
+<!-- 
 ## Reviews of premium versions are permitted (within reason)
+ -->
+## プレミアム版のレビューは、許可される (合理的な範囲内で)
 
+<!-- 
 This can be confusing.
+ -->
+これは混乱を招く可能性があります。
 
+<!-- 
 We believe users have the right to leave a review that includes details about a premium version of a plugin provided the following are true:
+ -->
+以下のことが真実である場合に限り、ユーザーがプレミアム版のプラグインに関する詳細を含むレビューを残す権利があると、私たちは考えています:
 
+<!-- 
 1. The plugin itself upsells/promotes the premium version either within the readme or the plugin settings page
 2. The review contains details about the functionality/usability of the plugin
 3. The review is **not** only a complaint about upselling
 4. The review does **not** contain harassment, abuse, vulgarities, or other attacks towards the developer
 5. The review is **not** about a premium-only plugin that is not hosted (whole or in part) on WordPress.org
+ -->
+1. プラグイン自体が、readme やプラグインの設定ページで、プレミアム版をアップセルしたり、宣伝している
+2. レビューに、プラグインの機能/ユーザビリティについての詳細が含まれている
+3. レビューが、アップセルについての苦情だけ **ではない** こと
+4. レビューに、開発者に対する嫌がらせ、罵倒、下品、その他の攻撃が含まれて **いない** こと
+5. WordPress.org 上で (全体または部分的に) ホストされていないプレミアムのみのプラグインに関するレビュー **ではない** こと
 
+<!-- 
 We do not tolerate abuse or harassment towards developers any more than we do towards users. That said, negative reviews are not, in and of themselves, always abusive. Sometimes people just don’t like your plugins, and that’s okay.
+ -->
+私たちは、ユーザーに対する以上に、開発者に対する虐待や嫌がらせを許しません。とはいえ、否定的なレビューそれ自体が、常に罵倒であるということではありません。時にはあなたのプラグインが気に入らない人も存在するでしょうし、それはそれで OK です。
 
+<!-- 
 ## Multiple accounts for a company are permitted (within reason)
+ -->
+## 1つの会社で複数のアカウントは、許可される (合理的な範囲内で)
 
+<!-- 
 The real issue here is that users don’t like talking to “MarvelTech100” as much as they like to talk to Carol Danvers. Faceless automatons are hard to connect with.
+ -->
+ここでの本当の課題は、ユーザーが、キャロル・ダンバース (つまり、キャプテン・マーヴェル) と話したいのと同じくらい、「MarvelTech100」と話すことを、好まないということなのです。顔の見えないオートマトンは、心を通わせるのが難しいのです。
 
+<!-- 
 That said, having a company account to own your plugin is perfectly logical and reasonable. However in those situations, the account is only intended to be the **owner** of the plugins/themes, and is **not** permitted to use the forums.
+ -->
+とはいえ、プラグインを所有するために企業アカウントを持つことは完全に論理的で合理的です。しかし、そのような状況では、そのアカウントはプラグイン/テーマの **所有者** であることを意図しているだけであり、フォーラムを使用することは「¥許可 **されていません**。
 
+<!-- 
 If you want to have two accounts, where one is your personal account and the other is “You at the company” that’s totally fine. People just prefer talking to people.
+ -->
+あなたがアカウントを2つ持ちたいなら、一方はあなたの個人的なアカウントで、もう一方は「会社のあなた」のアカウントでも全然かまいません。人は人と話すことを好むものです。
 
+<!-- 
 ## Sharing accounts is not permitted
+ -->
+## アカウントの共有は、許可されていない
 
+<!-- 
 Related to that, don’t share accounts. It causes confusion, drama, and makes it very difficult to unravel who you are if someone on your team violates the guidelines. It never ends well.
+ -->
+それに関連して、アカウントを共有しないでください。チームの誰かがガイドラインに違反した場合、混乱やドラマを引き起こし、あなたが誰なのかを解明するのが非常に難しくなります。良い結果には決してつながりません。


### PR DESCRIPTION
textlintチェック結果：エラーなし

作業用リモートリポジトリ（main）
![image](https://github.com/user-attachments/assets/819250fd-0de0-4409-9c98-0863e0fff9eb)

そこからブランチ
![image](https://github.com/user-attachments/assets/732b729e-406b-43de-ab21-98973b3be2eb)
※こちらに和訳ファイルを格納しました。