### PR TITLE
fixes #238 http-api/index.md APIからデータGET時の$argsパラメータのデフォルト値について

### DIFF
--- a/http-api/index.md
+++ b/http-api/index.md
@@ -182,14 +182,14 @@ The following defaults are assumed, though they can be changed via the $args par
 - `cookies` – array()
 
  -->
-- `method` – GET
-- `timeout` – 5 – 中止するまでの待ち時間
-- `redirection` – 5 – リダイレクトを何回実行するか
-- `httpversion` – 1.0
-- `blocking` – true – この操作が完了するまで、ページの残りの部分の読み込みを待つべきか ?
-- `headers` – array()
-- `body` – null
-- `cookies` – array()
+- `method` – `GET`
+- `timeout` – `5` – 中止するまでの待ち時間
+- `redirection` – `5` – リダイレクトを何回実行するか
+- `httpversion` – `1.0`
+- `blocking` – `true` – この操作が完了するまで、ページの残りの部分の読み込みを待つべきか ?
+- `headers` – `array()`
+- `body` – `null`
+- `cookies` – `array()`
 
 <!-- 
 Let's use the URL to a GitHub user account and see what sort of information we can get.


### PR DESCRIPTION
textlint再実施の結果、下記の様に誤判定された為、加工：
　186：– 5 => –5
　187：– 5 => –5
　188：– 1 => –1
　190：y( => y (
　192：y( => y (