### PR TITLE
fixes #302 wordpress-org/how-to-use-subversion/index.md textlint再実施

### DIFF
--- a/wordpress-org/how-to-use-subversion/index.md
+++ b/wordpress-org/how-to-use-subversion/index.md
@@ -418,7 +418,7 @@ svn diff
 <!-- 
 If it all looks good then it's time to check in those changes to the central repository.
  -->
-すべて問題がなさそうなら、変更を中央リポジトリにチェックインする時です。
+すべて問題がなさそうなら、変更を中央リポジトリにチェックインするときです。
 
 ```
 svn ci -m "fancy new feature: now you can foo *and* bar at the same time"


### PR DESCRIPTION
Fixes #302

textlint再実施の結果です： 
　421行目：時 => とき