### PR TITLE
fixes #324 hooks/advanced-topics/index.md typoの修正

### DIFF
--- a/hooks/advanced-topics/index.md
+++ b/hooks/advanced-topics/index.md
@@ -124,7 +124,7 @@ Some hooks are called multiple times in the course of execution, but you may onl
 <!-- 
 In this situation, you can check how many times the hook has run with the [` did_action()`](https://developer.wordpress.org/reference/functions/did_action/).
  -->
-この場合、フックが何回作動したかを [` did_action()`](https://developer.wordpress.org/reference/functions/did_action/) で確認できます。
+この場合、フックが何回作動したかを [`did_action()`](https://developer.wordpress.org/reference/functions/did_action/) で確認できます。
 
 ```
 function wporg_custom() {


### PR DESCRIPTION
Fixes #324

原文 125 行目：　` did_action()`
訳文 127 行目：　`did_action()`
