### PR TITLE
fixes #342 developer-tools/helper-plugins/index.md リンク先を日本語版プラグイン・ディレクトリに変更

### DIFF
--- a/developer-tools/helper-plugins/index.md
+++ b/developer-tools/helper-plugins/index.md
@@ -21,7 +21,7 @@ Additionally, the tool flags violations or concerns around plugin development be
 [Visit Plugin Check](https://wordpress.org/plugins/plugin-check/)
 -->
 
-[Plugin Check を見る](https://wordpress.org/plugins/plugin-check/)
+[Plugin Check を見る](https://ja.wordpress.org/plugins/plugin-check/)
 
 ## Query Monitor
 
@@ -33,4 +33,4 @@ Query Monitor は、WordPress で開発するすべての人のためのデバ�
 <!-- 
 [Visit Query Monitor](https://wordpress.org/plugins/query-monitor/)
  -->
-[Query Monitor を見る](https://wordpress.org/plugins/query-monitor/)
+[Query Monitor を見る](https://ja.wordpress.org/plugins/query-monitor/)


### PR DESCRIPTION
Fixes #342

原文 21 行目：https://wordpress.org/plugins/plugin-check/
和訳 24 行目：https://ja.wordpress.org/plugins/plugin-check/

原文 34 行目：https://wordpress.org/plugins/query-monitor/
和訳 36 行目：https://ja.wordpress.org/plugins/query-monitor/