### PR TITLE
fixes #344 internationalization/localization/index.md リンク先を日本語版プラグイン・ディレクトリに変更

### DIFF
--- a/internationalization/localization/index.md
+++ b/internationalization/localization/index.md
@@ -156,10 +156,16 @@ Here are a few tools that can be used to translate PO files online:
  -->
 PO ファイルをオンラインで翻訳するために使用できるツールをいくつか紹介します:
 
+<!-- 
 - [Transifex](https://www.transifex.com/)
 - [WebTranslateIt](https://webtranslateit.com/)
 - [Poeditor](https://poeditor.com/)
 - [GlotPress](https://wordpress.org/plugins/glotpress/)
+ -->
+- [Transifex](https://www.transifex.com/)
+- [WebTranslateIt](https://webtranslateit.com/)
+- [Poeditor](https://poeditor.com/)
+- [GlotPress](https://ja.wordpress.org/plugins/glotpress/)
 
 <!-- 
 ## Generate MO file


### PR DESCRIPTION
Fixes #344

原文 163 行目：https://wordpress.org/plugins/glotpress/
和訳 168 行目：https://ja.wordpress.org/plugins/glotpress/