### PR TITLE
fixes #346 wordpress-org/add-your-plugin-to-the-block-directory/index.md リンク先を日本語版プラグイン・ディレクトリに変更

### DIFF
--- a/wordpress-org/add-your-plugin-to-the-block-directory/index.md
+++ b/wordpress-org/add-your-plugin-to-the-block-directory/index.md
@@ -38,7 +38,7 @@ Block Plugins are required to be much smaller and more minimalist than a regular
 <!-- 
 If you’re a committer of a block plugin that does meet the criteria for adding it to the [Block Directory](https://wordpress.org/plugins/browse/block/) as confirmed by the Checker tool, you can then add it yourself [using the Block Checker tool](https://wordpress.org/plugins/developers/block-plugin-validator/):
  -->
-あなたがブロック・プラグインのコミッターである場合、チェッカーツールで確認した結果、[ブロックディレクトリ](https://ja.wordpress.org/plugins/browse/block/)に追加する条件を満たしていれば、[ブロックプラグイン・チェッカー・ツールを使って](https://ja.wordpress.org/plugins/developers/block-plugin-validator/)自分で追加できます:
+あなたがブロック・プラグインのコミッターである場合、チェッカーツールで確認した結果、[ブロックディレクトリ](https://ja.wordpress.org/plugins/browse/block/)に追加する条件を満たしていれば、[ブロックチェッカー・ツールを使って](https://ja.wordpress.org/plugins/developers/block-plugin-validator/)自分で追加できます:
 
 <!-- 
 ![](https://i0.wp.com/developer.wordpress.org/files/2020/08/Screen-Shot-2020-07-10-at-1.29.25-pm.png?resize=1024%2C308&ssl=1)

--- a/wordpress-org/add-your-plugin-to-the-block-directory/index.md
+++ b/wordpress-org/add-your-plugin-to-the-block-directory/index.md
@@ -38,7 +38,7 @@ Block Plugins are required to be much smaller and more minimalist than a regular
 <!-- 
 If you’re a committer of a block plugin that does meet the criteria for adding it to the [Block Directory](https://wordpress.org/plugins/browse/block/) as confirmed by the Checker tool, you can then add it yourself [using the Block Checker tool](https://wordpress.org/plugins/developers/block-plugin-validator/):
  -->
-あなたがブロック・プラグインのコミッターである場合、チェッカーツールで確認した結果、[ブロックディレクトリ](https://wordpress.org/plugins/browse/block/)に追加する条件を満たしていれば、[ブロックチェッカー・ツールを使って](https://wordpress.org/plugins/developers/block-plugin-validator/)自分で追加できます:
+あなたがブロック・プラグインのコミッターである場合、チェッカーツールで確認した結果、[ブロックディレクトリ](https://ja.wordpress.org/plugins/browse/block/)に追加する条件を満たしていれば、[ブロックプラグイン・チェッカー・ツールを使って](https://ja.wordpress.org/plugins/developers/block-plugin-validator/)自分で追加できます:
 
 <!-- 
 ![](https://i0.wp.com/developer.wordpress.org/files/2020/08/Screen-Shot-2020-07-10-at-1.29.25-pm.png?resize=1024%2C308&ssl=1)


### PR DESCRIPTION
Fixes #346

原文 39 行目：https://wordpress.org/plugins/browse/block/
原文 39 行目：https://wordpress.org/plugins/developers/block-plugin-validator/
和訳 41 行目：https://ja.wordpress.org/plugins/browse/block/
和訳 41 行目：https://ja.wordpress.org/plugins/developers/block-plugin-validator/