### PR TITLE
fixes #348 wordpress-org/block-specific-plugin-guidelines/index.md リンク先を日本語版プラグイン・ディレクトリに変更

### DIFF
--- a/wordpress-org/block-specific-plugin-guidelines/index.md
+++ b/wordpress-org/block-specific-plugin-guidelines/index.md
@@ -16,7 +16,7 @@
 <!-- 
 The goal of the [Block Directory](https://wordpress.org/plugins/browse/block/) is to provide a safe place for WordPress users to find and install new blocks.
  -->
-[ブロック・ディレクトリ](https://wordpress.org/plugins/browse/block/)の目指すところは、WordPress ユーザーが新しいブロックを見つけてインストールするための安全な場所を提供することです。
+[ブロック・ディレクトリ](https://ja.wordpress.org/plugins/browse/block/)の目指すところは、WordPress ユーザーが新しいブロックを見つけてインストールするための安全な場所を提供することです。
 
 <!-- 
 ### User Expectations


### PR DESCRIPTION
Fixes #348

原文 17 行目：https://wordpress.org/plugins/browse/block/
和訳 19 行目：https://ja.wordpress.org/plugins/browse/block/