### PR TITLE
fixes #367 javascript/jquery/index.md リンクのタイトルの見直し（和訳）

### DIFF
--- a/javascript/jquery/index.md
+++ b/javascript/jquery/index.md
@@ -11,7 +11,7 @@
 <!-- 
 Your jQuery script runs on the user's browser after your WordPress webpage is received. A basic jQuery statement has two parts: a selector that determines which HTML elements the code applies to, and an action or event, which determines what the code does or what it reacts to. The basic event statement looks like this:
  -->
-jQuery スクリプトは、WordPress の Web ページを受信した後、ユーザーのブラウザー上で実行されます。基本的な jQuery ステートメントには2つの部分があります: コードが適用される HTML 要素を決定するセレクタ、そして、コードが何をするか、何に反応するかを決定するアクションまたはイベントです。基本的なイベントステートメントは、次のようになります:
+jQuery スクリプトは、WordPress の Web ページを受信した後、ユーザーのブラウザー上で実行されます。基本的な jQuery ステートメントには2つの部分があります: コードが適用される HTML 要素を決定するセレクター、そして、コードが何をするか、何に反応するかを決定するアクションまたはイベントです。基本的なイベントステートメントは、次のようになります:
 
 ```
 jQuery.(selector).event(function);
@@ -20,7 +20,7 @@ jQuery.(selector).event(function);
 <!-- 
 When an event, such as a mouse click, occurs in an HTML element selected by the selector, the function that is defined inside the final set of parentheses is executed.
  -->
-セレクタで選択された HTML 要素で、マウスクリックなど、イベントが発生した際、最後の括弧の中で定義された関数が実行されます。
+セレクターで選択された HTML 要素で、マウスクリックなど、イベントが発生した際、最後の括弧の中で定義された関数が実行されます。
 
 <!-- 
 All the following code examples are based on this HTML page content. Assume it appears on your plugin's admin settings screen, defined by the file `myplugin_settings.php`. It is a simple table with radio buttons next to each title.
@@ -62,12 +62,12 @@ In the [article on AJAX](https://developer.wordpress.org/plugins/javascript/ajax
 <!-- 
 ### Selector and Event
  -->
-### セレクタとイベント
+### セレクターとイベント
 
 <!-- 
 The selector is the same form as CSS selectors: `.class` or `#id`. There's many [more forms](https://api.jquery.com/category/selectors/ "jQuery Reference"), but these are the two you will frequently use. In our example, we will use class `.pref`. There's also a slew of possible [events](https://api.jquery.com/category/events/ "jQuery Reference"), one you will likely use a lot is _‘click'_. In our example we will use _‘change'_ to capture a radio button selection. Be aware that jQuery events are often named somewhat differently than those with JavaScript. So far, after we add in an empty anonymous function, our example statement looks like this:
  -->
-セレクタは CSS セレクタと同じ形式です: `.class` または `#id`。もっと[多くの形式](https://api.jquery.com/category/selectors/ "jQuery リファレンス")がありますが、よく使うのはこの2つです。この例では、クラス `.pref` を使用します。また、[イベント](https://api.jquery.com/category/events/ "jQuery リファレンス")はたくさんありますが、その中でもよく使うのは _‘click'_ でしょう。この例では、_‘change'_ を使ってラジオボタンの選択を捕捉します。jQuery のイベントの名前は、JavaScript のイベントとは多少異なることが多いので、注意してください。ここまでで、空の無名関数を追加すると、例のステートメントは次のようになります:
+セレクターは CSS セレクターと同じ形式です: `.class` または `#id`。もっと[多くの形式](https://api.jquery.com/category/selectors/ "jQuery リファレンス")がありますが、よく使うのはこの2つです。この例では、クラス `.pref` を使用します。また、[イベント](https://api.jquery.com/category/events/ "jQuery リファレンス")はたくさんありますが、その中でもよく使うのは _‘click'_ でしょう。この例では、_‘change'_ を使ってラジオボタンの選択を捕捉します。jQuery のイベントの名前は、JavaScript のイベントとは多少異なることが多いので、注意してください。ここまでで、空の無名関数を追加すると、例のステートメントは次のようになります:
 
 ```
 $.(".pref").change(function(){

--- a/javascript/jquery/index.md
+++ b/javascript/jquery/index.md
@@ -20,7 +20,7 @@ jQuery.(selector).event(function);
 <!-- 
 When an event, such as a mouse click, occurs in an HTML element selected by the selector, the function that is defined inside the final set of parentheses is executed.
  -->
-セレクターで選択された HTML 要素で、マウスクリックなど、イベントが発生した際、最後の括弧の中で定義された関数が実行されます。
+セレクタで選択された HTML 要素で、マウスクリックなど、イベントが発生した際、最後の括弧の中で定義された関数が実行されます。
 
 <!-- 
 All the following code examples are based on this HTML page content. Assume it appears on your plugin's admin settings screen, defined by the file `myplugin_settings.php`. It is a simple table with radio buttons next to each title.
@@ -62,12 +62,12 @@ In the [article on AJAX](https://developer.wordpress.org/plugins/javascript/ajax
 <!-- 
 ### Selector and Event
  -->
-### セレクターとイベント
+### セレクタとイベント
 
 <!-- 
 The selector is the same form as CSS selectors: `.class` or `#id`. There's many [more forms](https://api.jquery.com/category/selectors/ "jQuery Reference"), but these are the two you will frequently use. In our example, we will use class `.pref`. There's also a slew of possible [events](https://api.jquery.com/category/events/ "jQuery Reference"), one you will likely use a lot is _‘click'_. In our example we will use _‘change'_ to capture a radio button selection. Be aware that jQuery events are often named somewhat differently than those with JavaScript. So far, after we add in an empty anonymous function, our example statement looks like this:
  -->
-セレクターは CSS セレクタと同じ形式です: `.class` または `#id`。もっと[多くの形式](https://api.jquery.com/category/selectors/ "jQuery Reference")がありますが、よく使うのはこの2つです。この例では、クラス `.pref` を使用します。また、[イベント](https://api.jquery.com/category/events/ "jQuery Reference")はたくさんありますが、その中でもよく使うのは _‘click'_ でしょう。この例では、_‘change'_ を使ってラジオボタンの選択を捕捉します。jQuery のイベントの名前は、JavaScript のイベントとは多少異なることが多いので、注意してください。ここまでで、空の無名関数を追加すると、例のステートメントは次のようになります:
+セレクタは CSS セレクタと同じ形式です: `.class` または `#id`。もっと[多くの形式](https://api.jquery.com/category/selectors/ "jQuery リファレンス")がありますが、よく使うのはこの2つです。この例では、クラス `.pref` を使用します。また、[イベント](https://api.jquery.com/category/events/ "jQuery リファレンス")はたくさんありますが、その中でもよく使うのは _‘click'_ でしょう。この例では、_‘change'_ を使ってラジオボタンの選択を捕捉します。jQuery のイベントの名前は、JavaScript のイベントとは多少異なることが多いので、注意してください。ここまでで、空の無名関数を追加すると、例のステートメントは次のようになります:
 
 ```
 $.(".pref").change(function(){


### PR DESCRIPTION
また、textlint エラー（セレクター => セレクタ）への対応も実施