### PR TITLE
wordpress-org/transferring-your-plugin-to-a-new-owner/index.md 和訳の追加

### DIFF
--- a/wordpress-org/transferring-your-plugin-to-a-new-owner/index.md
+++ b/wordpress-org/transferring-your-plugin-to-a-new-owner/index.md
@@ -40,7 +40,10 @@ If there are no other committers, the plugin will not be available to be transfe
  -->
 他のコミッターが居ない場合、プラグインは譲渡されないので、まずそれを行う必要があります。
 
+<!-- 
 ![Transfer this plugin interface with a selector for the new owner and a "Please transfer -Plugin Name-" button](https://i0.wp.com/developer.wordpress.org/files/2020/04/transfer.jpeg?resize=1024%2C558&ssl=1)
+ -->
+![セレクタと「-プラグイン名-を委譲します」ボタンインターフェイスで、新しいオーナーにこのプラグインを譲渡する](https://i0.wp.com/developer.wordpress.org/files/2020/04/transfer.jpeg?resize=1024%2C558&ssl=1)
 
 <!-- 
 ## For Plugins with OVER 10,000 Users (or are beta/featured)

--- a/wordpress-org/transferring-your-plugin-to-a-new-owner/index.md
+++ b/wordpress-org/transferring-your-plugin-to-a-new-owner/index.md
@@ -43,7 +43,7 @@ If there are no other committers, the plugin will not be available to be transfe
 <!-- 
 ![Transfer this plugin interface with a selector for the new owner and a "Please transfer -Plugin Name-" button](https://i0.wp.com/developer.wordpress.org/files/2020/04/transfer.jpeg?resize=1024%2C558&ssl=1)
  -->
-![セレクタと「-プラグイン名-を委譲します」ボタンインターフェイスで、新しいオーナーにこのプラグインを譲渡する](https://i0.wp.com/developer.wordpress.org/files/2020/04/transfer.jpeg?resize=1024%2C558&ssl=1)
+![セレクタと「-プラグイン名-を譲渡します」ボタンインターフェースで、新しいオーナーにこのプラグインを譲渡する](https://i0.wp.com/developer.wordpress.org/files/2020/04/transfer.jpeg?resize=1024%2C558&ssl=1)
 
 <!-- 
 ## For Plugins with OVER 10,000 Users (or are beta/featured)


### PR DESCRIPTION
Fixes #370 

画像リンクに代替テキスト追加