### PR TITLE
textlintエラーの修正

### DIFF
--- a/rest-api/requests/index.md
+++ b/rest-api/requests/index.md
@@ -209,7 +209,7 @@ PHP では、クエリー・パラメータは、スーパーグローバル `$_
 Body parameters are key value pairs that are stored in the request body. If you have ever sent a `POST` request via a , through cURL, or some other method, then you have used body parameters. With body parameters you can pass them as different content types as well. The default `Content-Type` header for a `POST` request is `x-www-form-urlencoded`. When using `x-www-form-urlencoded`, the parameters are sent like a query string; `per_page=2&genre=fiction`. An HTML form, by default, will bundle up the various inputs and send a `POST` request matching the `x-www-form-urlencoded` pattern.
 -->
 
-ボディ・パラメータは、リクエスト・ボディに格納される KVP (キーと値のペア) です。これまでに cURL やその他の方法を使用して `POST` リクエストを送信したことがあれば、ボディ・パラメータを使ったことがあるはずです。ボディ・パラメータでは、異なるコンテントタイプとして渡すこともできます。リクエスト `POST` に対するデフォルトのヘッダー `Content-Type` は、`x-www-form-urlencoded` です。`x-www-form-urlencoded` を使用する場合、パラメータはクエリー文字列のように送信されます; `per_page=2&genre=fiction`。デフォルトでは、HTML フォームは、さまざまな入力を束ね、パターン `x-www-form-urlencoded` に一致するリクエスト `POST` を送信します。
+ボディ・パラメータは、リクエスト・ボディに格納される KVP (キーと値のペア) です。これまでに cURL やその他の方法を使用して `POST` リクエストを送信したことがあれば、ボディ・パラメータを使ったことがあるはずです。ボディ・パラメータでは、異なるコンテンツタイプとして渡すこともできます。リクエスト `POST` に対するデフォルトのヘッダー `Content-Type` は、`x-www-form-urlencoded` です。`x-www-form-urlencoded` を使用する場合、パラメータはクエリー文字列のように送信されます; `per_page=2&genre=fiction`。デフォルトでは、HTML フォームは、さまざまな入力を束ね、パターン `x-www-form-urlencoded` に一致するリクエスト `POST` を送信します。
 
 <!--
 It is important to note that although the HTTP specification does not prohibit the use of sending body parameters in `GET` requests, it is encouraged that you do not use body parameters in a `GET` request. Body parameters can and should be used for `POST`, `PUT`, and `DELETE` requests.
@@ -227,7 +227,7 @@ HTTP の仕様では `GET` リクエストでボディ・パラメータを送�
 File parameters in a `WP_REST_Request` object are stored when the request uses a special content type header; `multipart/form-data`. The file data can then be accessed from the request object using `$request->get_file_params()`. The file parameters are equivalent to the PHP superglobal: `$_FILES`. Remember, do not access the superglobals directly only use what the `WP_REST_Request` object provides.
 -->
 
-オブジェクト `WP_REST_Request` のファイル・パラメータは、リクエストが特別なコンテントタイプ・ヘッダー `multipart/form-data` を使用する場合に格納されます。ファイルデータは、リクエストオブジェクトから `$request->get_file_params()` を使ってアクセスできます。ファイル・パラメータは PHP のスーパーグローバル `$_FILES` と同じです。スーパーグローバルに直接アクセスせず、オブジェクト `WP_REST_Request` が提供するものだけを使用することを忘れないでください。
+オブジェクト `WP_REST_Request` のファイル・パラメータは、リクエストが特別なコンテンツタイプ・ヘッダー `multipart/form-data` を使用する場合に格納されます。ファイルデータは、リクエストオブジェクトから `$request->get_file_params()` を使ってアクセスできます。ファイル・パラメータは PHP のスーパーグローバル `$_FILES` と同じです。スーパーグローバルに直接アクセスせず、オブジェクト `WP_REST_Request` が提供するものだけを使用することを忘れないでください。
 
 <!--
 In the endpoint callback we could use `wp_handle_upload()` to then add in the desired files to WordPress’s media uploads directory. The file parameters are only useful for dealing with file data and you should never use them for any other purpose.

--- a/wordpress-org/how-your-readme-txt-works/index.md
+++ b/wordpress-org/how-your-readme-txt-works/index.md
@@ -14,7 +14,7 @@ This page will explain some aspects of the plugin directory, and explain of the 
 To make your entry in the plugin browser most useful, each plugin should have a readme file named `readme.txt` that adheres to the [WordPress plugin readme file standard](https://wordpress.org/plugins/readme.txt). This file controls the output on the front-facing part of the directory. Writing a description in the readme determines exactly what will be displayed on `wordpress.org/plugins/Your-Plugin`
 -->
 
-プラグイン・ブラウザのエントリを最も有用なものにするために、各プラグインは、[WordPress プラグイン readme ファイル標準](https://ja.wordpress.org/plugins/readme.txt)に準拠した `readme.txt` という名称の readme ファイルを持つ必要があります。このファイルは、ディレクトリのフロントページの出力を制御します。readme に詳細を記述することで、`wordpress.org/plugins/Your-Plugin` に何が表示されるかが決まります。
+プラグイン・ブラウザのエントリーを最も有用なものにするために、各プラグインは、[WordPress プラグイン readme ファイル標準](https://ja.wordpress.org/plugins/readme.txt)に準拠した `readme.txt` という名称の readme ファイルを持つ必要があります。このファイルは、ディレクトリのフロントページの出力を制御します。readme に詳細を記述することで、`wordpress.org/plugins/Your-Plugin` に何が表示されるかが決まります。
 
 <!--
 You can use the [plugin readme generator](https://generatewp.com/plugin-readme/) and put your completed result through the [official readme validator](https://wordpress.org/plugins/developers/readme-validator/) to check it. If you need more visual assistance you can use the tool [wpreadme.com](https://wpreadme.com/)
@@ -211,10 +211,6 @@ Markdown allows for easy linking in your readme.txt as well. Just write like thi
 -->
 
 Markdown を使えば、readme.txt にも簡単にリンクを張ることができます。単語を URL にリンクさせるには、このように書くだけです:
-
-<!--
-\[WordPress\](http://wordpress.org)
--->
 
 \[WordPress\](http://wordpress.org)
 

--- a/wordpress-org/plugin-developer-faq/index.md
+++ b/wordpress-org/plugin-developer-faq/index.md
@@ -1091,7 +1091,7 @@ Assuming you actually did apply for trademarks, you certainly _can_ but it's not
 ### How long will it take for my plugin to show up in search?
 -->
 
-### 私のプラグインが検索に表示されるまで、どのくらい掛かりますか ?
+### 私のプラグインが検索に表示されるまで、どのくらいかかりますか ?
 
 <!--
 Usually 6 to 14 days after a plugin is committed to SVN. This is because we have to add your data, parse it, and share it to all of our _heavily_ cached servers. It's not instantaneous. Also as a new plugin, we have no data on usage, so you may need to wait a bit.

--- a/wordpress-org/special-user-roles-capabilities/index.md
+++ b/wordpress-org/special-user-roles-capabilities/index.md
@@ -14,7 +14,7 @@ Every person who pushes code for, or aids in support for, a plugin is required t
 There are four roles a user can have with regards to plugins. All can be managed from the **advanced view** section of a plugin page:
 -->
 
-プラグインに関して、ユーザーが持てる4つの権限グループがあります。すべてプラグインページの **詳細表示** セクションから管理できます:
+プラグインに関して、ユーザーが持つことができる4つの権限グループがあります。すべてプラグインページの **詳細表示** セクションから管理できます:
 
 <!--
 ![Interface of the plugin page, the link ''Advanced View'' is highlighted.](https://i0.wp.com/developer.wordpress.org/files/2020/08/advanced-view.jpg?resize=300%2C260&ssl=1)


### PR DESCRIPTION
`npm run textlint .` で検出されたエラーのうち、誤検出ではなく修正できるものを修正しました。