### PR TITLE
ショートコードのエスケープ

### DIFF
--- a/shortcodes/index.md
+++ b/shortcodes/index.md
@@ -69,12 +69,12 @@ By default, WordPress includes the following shortcodes:
 - `[embed]` – allows you to wrap embedded items
 -->
 
-- `caption` – コンテンツのキャプションをラップ (回り込み) できます。
-- `gallery` – 画像ギャラリーを表示できます。
-- `audio` – 音声ファイルを埋め込んで再生できます。
-- `video` – 動画ファイルを埋め込んで再生できます。
-- `playlist` – オーディオファイルやビデオファイルのコレクションを表示できます。
-- `embed` – 埋め込み項目をラップ (回り込み) できます。
+- `[[caption]]` – コンテンツのキャプションをラップ (回り込み) できます。
+- `[[gallery]]` – 画像ギャラリーを表示できます。
+- `[[audio]]` – 音声ファイルを埋め込んで再生できます。
+- `[[video]]` – 動画ファイルを埋め込んで再生できます。
+- `[[playlist]]` – オーディオファイルやビデオファイルのコレクションを表示できます。
+- `[[embed]]` – 埋め込み項目をラップ (回り込み) できます。
 
 <!--
 ## Shortcode Best Practices

--- a/shortcodes/tinymce-enhanced-shortcodes/index.md
+++ b/shortcodes/tinymce-enhanced-shortcodes/index.md
@@ -32,7 +32,7 @@ Below are the built-in WordPress shortcodes that use this functionality.
 The `[audio]` shortcode allows you to embed a single audio file.
 -->
 
-ショートコード `&#91;audio&#93;` は、1つの音声ファイルを埋め込むことができます。
+ショートコード `[[audio]]` は、1つの音声ファイルを埋め込むことができます。
 
 <!--
 ![The audio shortcode](https://i3.wp.com/developer.wordpress.org/files/2014/09/shortcodes-tinymce-enhanced-shortcodes-01.png)
@@ -50,7 +50,7 @@ The `[audio]` shortcode allows you to embed a single audio file.
 The `[caption]` shortcode wraps the image in a div and puts a `<p class="wp-caption-text">` tag around the caption.
 -->
 
-ショートコード `&#91;caption&#93;` は、画像を div で囲み、キャプションをタグ `<p class="wp-caption-text">` で囲みます。
+ショートコード `[[caption]]` は、画像を div で囲み、キャプションをタグ `<p class="wp-caption-text">` で囲みます。
 
 <!--
 ![The caption shortcode](https://i3.wp.com/developer.wordpress.org/files/2014/09/shortcodes-tinymce-enhanced-shortcodes-02.png)
@@ -68,7 +68,7 @@ The `[caption]` shortcode wraps the image in a div and puts a `<p class="wp-capt
 The `[gallery]` shortcode allows you to embed several images at once in a div.
 -->
 
-ショートコード `&#91;gallery&#93;` を使うと、複数の画像を一度に div に埋め込むことができます。
+ショートコード `[[gallery]]` を使うと、複数の画像を一度に div に埋め込むことができます。
 
 <!--
 ![The gallery shortcode](https://i3.wp.com/developer.wordpress.org/files/2014/09/shortcodes-tinymce-enhanced-shortcodes-03.png)
@@ -86,7 +86,7 @@ The `[gallery]` shortcode allows you to embed several images at once in a div.
 The `[playlist]` shortcode allows you to attach more than one media file and render with an html5 playlist.
 -->
 
-ショートコード `&#91;playlist&#93;` は、複数のメディアファイルを添付し、html5プレイリストでレンダリングできます。
+ショートコード `[[playlist]]` は、複数のメディアファイルを添付し、html5プレイリストでレンダリングできます。
 
 <!--
 ![The playlist shortcode](https://i3.wp.com/developer.wordpress.org/files/2014/09/shortcodes-tinymce-enhanced-shortcodes-04.png)
@@ -104,7 +104,7 @@ The `[playlist]` shortcode allows you to attach more than one media file and ren
 The `[video]` shortcode is very similar to the `[audio]` shortcode, it simply renders a video instead of audio.
 -->
 
-ショートコード `&#91;video&#93;` は、ショートコード `&#91;audio&#93;` とよく似ており、音声の代わりに動画をレンダリングします。
+ショートコード `[[video]]` は、ショートコード `[[audio]]` とよく似ており、音声の代わりに動画をレンダリングします。
 
 <!--
 ![The video shortcode](https://i3.wp.com/developer.wordpress.org/files/2014/09/shortcodes-tinymce-enhanced-shortcodes-05.png)


### PR DESCRIPTION
ショートコードを文字列そのものとして表示させるために、ダブルカッコによってエスケープします。